### PR TITLE
Update Docker image responsible for issues

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/node:8.11.3
+FROM node:8.11-stretch
 
 ENV NODE_ENV production
 ENV PORT 3000


### PR DESCRIPTION
Many of the issues refer to an error while pulling form dockerhub. This is due to the jessie node repository. The stretch one does not cause the error. I have tested it twice on Ubuntu 18.04 machines and it successfully fixes the issue for me.